### PR TITLE
fix column name

### DIFF
--- a/csv/views/view05a_RA_source_G44.csv
+++ b/csv/views/view05a_RA_source_G44.csv
@@ -1,4 +1,4 @@
-act_id,act_object,obj_title
+act_id,act_object,title
 A00001,W0002,English 900
 A00004,W0004,Ticket to the Stars
 A00005,W0004,Ticket to the Stars


### PR DESCRIPTION
To fit the vega editor in ReadChina, the column name `obj_title` should be replaced with `title`.